### PR TITLE
New feature: Configurable prefix

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+* text=auto
+
+*.js   eol=lf
+*.json eol=lf
+*.md   eol=lf
+*.yml  eol=lf
+
+*.tgz  binary

--- a/README.md
+++ b/README.md
@@ -62,3 +62,8 @@ MIT License (MIT)
 ## Contributing
 
 If you find a bug or think about enhancement, feel free to contribute and submit an issue or a pull request.
+
+To work in TDD mode:
+
+    npm install -g jasmine-node@2
+    jasmine-node test --autoTest --watchFolders src

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Or, if you use bower locally:
 npm install bower-npm-resolver
 ```
 
-## Configuration
+## Configuration and usage
 
 ### .bowerrc
 
@@ -32,17 +32,52 @@ Add the resolver in your `.bowerrc` file:
 }
 ```
 
-## Usage
-
-Once configured, your bower.json files may reference packages using `npm/` prefix:
+Once configured, your bower.json files may reference packages using `npm+` prefix:
 
 ```json
 {
   "dependencies": {
-    "npm+package-name": "1.0.0"
+    "npm+foobar": "1.0.0",
+    "other": "1.0.0"
   }
 }
 ```
+
+The resolver will match packages with `npm+` prefix, and strip the prefix prior to fetching from npm repo.
+In the example above, `foobar` will be fetched from npm. `other` will not be matched by this resolver.
+
+If this is not what you want, you can pass configuration parameters in `.bowerrc`.
+
+If you use a private npm repository for all your company's packages, and they all start with a shared prefix,
+you can change the prefix:
+
+```json
+{
+  "resolvers": [
+    "bower-npm-resolver"
+  ],
+  "bowerNpmResolver": {
+    "matchPrefix": "mycompanynpmpackages-",
+    "stripPrefix": false
+  }
+}
+```
+
+Then in your `bower.json`:
+
+```json
+{
+  "dependencies": {
+    "mycompanynpmpackages-foobar": "1.0.0",
+    "other": "1.0.0"
+  }
+}
+```
+
+In the example above, `mycompanynpmpackages-foobar` will be fetched from npm. `other` will not be matched by this resolver.
+
+
+## Features
 
 This resolver will:
 - Use NPM commands to get the version (and the list of available versions) to download.

--- a/src/resolver.js
+++ b/src/resolver.js
@@ -35,10 +35,12 @@ var extract = require('./extract');
 var bowerUtils = require('./bower-utils');
 
 module.exports = function resolver() {
+  var DEFAULT_PREFIX = 'npm+';
+
   // Extract the package identifier.
   var extractPackageName = function(source) {
     var parts = source.split('=');
-    return parts[0].slice(4);
+    return parts[0].slice(DEFAULT_PREFIX.length);
   };
 
   // Resolver factory returns an instance of resolver
@@ -51,7 +53,7 @@ module.exports = function resolver() {
      * @return {boolean} `true` if source match this resolver, `false` otherwise.
      */
     match: function(source) {
-      return source.indexOf('npm+') === 0;
+      return source.indexOf(DEFAULT_PREFIX) === 0;
     },
 
     /**

--- a/src/resolver.js
+++ b/src/resolver.js
@@ -34,13 +34,25 @@ var download = require('./download');
 var extract = require('./extract');
 var bowerUtils = require('./bower-utils');
 
-module.exports = function resolver() {
-  var DEFAULT_PREFIX = 'npm+';
+module.exports = function resolver(bower) {
+  var DEFAULT_MATCH_PREFIX = 'npm+';
+  var DEFAULT_STRIP_PREFIX = true;
+
+  // Read configuration passed via .bowerrc
+  var cfg = bower.config.bowerNpmResolver || {};
+  var matchPrefix = cfg.matchPrefix || DEFAULT_MATCH_PREFIX;
+  var stripPrefix = ('stripPrefix' in cfg) ? Boolean(cfg.stripPrefix) : DEFAULT_STRIP_PREFIX;
 
   // Extract the package identifier.
   var extractPackageName = function(source) {
     var parts = source.split('=');
-    return parts[0].slice(DEFAULT_PREFIX.length);
+    var pkgName = parts[0];
+
+    if (stripPrefix) {
+      pkgName = pkgName.slice(matchPrefix.length);
+    }
+
+    return pkgName;
   };
 
   // Resolver factory returns an instance of resolver
@@ -48,12 +60,14 @@ module.exports = function resolver() {
 
     /**
      * Match method tells whether resolver supports given source.
+     * By default, the resolver matches entries whose key name in `bower.json` starts with `npm+` string.
+     * This is configurable via `bowerNpmResolver.prefix` property in `.bowerrc`.
      *
      * @param {string} source Source from `bower.json`.
      * @return {boolean} `true` if source match this resolver, `false` otherwise.
      */
     match: function(source) {
-      return source.indexOf(DEFAULT_PREFIX) === 0;
+      return source.indexOf(matchPrefix) === 0;
     },
 
     /**

--- a/test/resolver-spec.js
+++ b/test/resolver-spec.js
@@ -22,6 +22,7 @@
  * SOFTWARE.
  */
 
+var path = require('path');
 var Q = require('q');
 var factory = require('../src/resolver');
 var npmUtils = require('../src/npm-utils');
@@ -111,7 +112,7 @@ describe('resolver', function() {
     var tarballUrl = 'http://registry.npmjs.org/bower/-/bower-1.7.7.tgz';
     var tarballPath = '/tmp/bower.tgz';
     var pkgPath = '/tmp/bower';
-    var bowerPkgPath = pkgPath + '/package';
+    var bowerPkgPath = path.normalize(pkgPath + '/package');
 
     d1.resolve(tarballUrl);
 

--- a/test/resolver-spec.js
+++ b/test/resolver-spec.js
@@ -35,12 +35,29 @@ describe('resolver', function() {
 
   beforeEach(function() {
     resolver = factory({
+      config: {},
       version: '1.7.7'
     });
   });
 
-  it('should match npm source', function() {
+  it('should match npm source by default', function() {
     expect(resolver.match('npm+test')).toBe(true);
+    expect(resolver.match('test')).toBe(false);
+  });
+
+  it('should match custom prefix when passed', function() {
+    resolver = factory({
+      config: {
+        bowerNpmResolver: {
+          matchPrefix: 'mycompany'
+        }
+      },
+      version: '1.7.7'
+    });
+
+    expect(resolver.match('mycompany-test')).toBe(true);
+
+    expect(resolver.match('npm+test')).toBe(false);
     expect(resolver.match('test')).toBe(false);
   });
 
@@ -72,6 +89,25 @@ describe('resolver', function() {
 
     result.then(success, error);
     defer.resolve(['1.0.0', '2.0.0']);
+  });
+
+  it('should not strip prefix from package name if stripPrefix=false', function() {
+    resolver = factory({
+      config: {
+        bowerNpmResolver: {
+          matchPrefix: 'mycompany',
+          stripPrefix: false
+        }
+      },
+      version: '1.7.7'
+    });
+
+    spyOn(npmUtils, 'releases').and.returnValue(Q.when());
+
+    var source = 'mycompany-foobar=mycompany-foobar';
+    resolver.releases(source);
+
+    expect(npmUtils.releases).toHaveBeenCalledWith('mycompany-foobar');
   });
 
   it('should fetch release', function(done) {


### PR DESCRIPTION
Hello @mjeanroy,

thanks for the work on this project, I used it in my company it fit pretty well to our needs. We're using my fork and it works fine, so I thought I'll open a PR and maybe you will want to merge it to mainline.

Our use case is as follows: we have one git repo with multiple bower packages. We want separate packages to better split things, but OTOH, the packages obviously interdepend on each other so it's easier to keep them in one repo in order to have atomic refactorings, make sure everything's green with just one build etc. Bower does not support this kind of workflow (one bower artifact = one git repo so we can't use git resolver; URL resolver supports only `*` target, no versioned targets) so we needed something custom.

We're using a private bower registry and private npm registry so our resolver fit our needs in principle.
Some small changes that we had to do:

- the `npm+` part turned out problematic because we're using some other bower tooling (wiredep) that didn't understand the `npm+` prefix and were failing, so we settled on a solution where each package under our control has `companyname-` prefix in its bower package name. Since we only use npm resolver for those packages, I added a config option to use company name as a prefix instead of `npm`, and another option to not strip the prefix when asking npm for the package. This way bower tooling is happy because bower.json entry matches the package name
- other small changes (test and gitattributes) to make things work fine on Windows

The PR passes the `npm run lint` and `npm test` (I actually had to change code a bit to make linter happy)

Let me know if this looks good to you or if you want some changes in the code / coding style / doc etc.