### PR TITLE
Allow user provided match patterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,11 +28,12 @@
   },
   "homepage": "https://github.com/mjeanroy/bower-npm-resolver",
   "dependencies": {
+    "escape-string-regexp": "^1.0.5",
     "npm": ">=1.0.0",
-    "tmp": "0.0.28",
     "q": "1.4.1",
     "request": "2.72.0",
     "tar-fs": "1.12.0",
+    "tmp": "0.0.28",
     "underscore": "1.8.3"
   },
   "devDependencies": {

--- a/src/bower-utils.js
+++ b/src/bower-utils.js
@@ -77,7 +77,7 @@ module.exports = {
             ]);
 
             // scoped packages get special treatment
-            // See https://github.com/npm/npm/blob/2a5977e0c65b244e92d848fcd56f2f80ba8cdf3b/lib/pack.js#L53
+            // See https://github.com/npm/npm/blob/v3.9.1/lib/pack.js#L53
             if (newConfig.name[0] === '@') {
               newConfig.name = newConfig.name.substr(1).replace(/\//g, '-');
             }

--- a/src/bower-utils.js
+++ b/src/bower-utils.js
@@ -76,6 +76,12 @@ module.exports = {
               'repository'
             ]);
 
+            // scoped packages get special treatment
+            // See https://github.com/npm/npm/blob/2a5977e0c65b244e92d848fcd56f2f80ba8cdf3b/lib/pack.js#L53
+            if (newConfig.name[0] === '@') {
+              newConfig.name = newConfig.name.substr(1).replace(/\//g, '-');
+            }
+
             // Do not try to translate dependencies.
             // Maybe be can try to deduce the dependencies ?
             newConfig.dependencies = {};

--- a/src/matcher-utils.js
+++ b/src/matcher-utils.js
@@ -86,7 +86,7 @@ function matchersExec(source) {
 
 var NPM_SCHEME_PATTERN = '^npm:/{0,3}(?!/)';
 // var NPM_SCHEME_PATTERN_VALID_ONLY = '^npm:(?:/?|///)(?!\\/)';
-var NPM_PREFIX_PATTERN = '^' + escapeStringRegexp('npm+');
+var NPM_PREFIX = 'npm+';
 
 /**
  * Creates a list of matchers from the config, providing default matchers if necessary
@@ -121,7 +121,7 @@ exports.getFromConfig = function getFromConfig(config) {
       replace: true
     });
     patterns.push({
-      pattern: NPM_PREFIX_PATTERN,
+      prefix: NPM_PREFIX,
       replace: true
     });
   }
@@ -143,7 +143,9 @@ exports.getFromConfig = function getFromConfig(config) {
       throw new Error('Invalid match value: ' + pattern);
     }
 
-    var regexp = pattern.regexp || new RegExp(pattern.pattern, pattern.flags);
+    var patternString = pattern.pattern || (pattern.prefix ? '^' + escapeStringRegexp(pattern.prefix) : null);
+
+    var regexp = pattern.regexp || new RegExp(patternString, pattern.flags);
     var replace;
 
     if (pattern.replace === true) {

--- a/src/matcher-utils.js
+++ b/src/matcher-utils.js
@@ -1,0 +1,165 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Mickael Jeanroy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * This module is used to parse the config and generate matchers.
+ */
+
+var escapeStringRegexp = require('escape-string-regexp');
+
+/**
+ * Matcher that tests a source against a regexp
+ * and replaces the match to produce a clean source
+ * @param {RegExp} regexp A regular expression to match against
+ * @param {string?} replace A string to replace the match with if necessary
+ * @constructor
+ */
+function Matcher(regexp, replace) {
+  this.regexp = regexp;
+  this.replace = replace;
+}
+
+/**
+ * Test the matcher against the source
+ * @param {string} source Source
+ * @return {boolean} Match result
+ */
+Matcher.prototype.test = function(source) {
+  return this.regexp.test(source);
+};
+
+/**
+ * Executes the matcher against the source
+ * @param {string} source Source
+ * @return {string} Cleaned up result
+ */
+Matcher.prototype.exec = function(source) {
+  return this.replace === undefined ? source : source.replace(this.regexp, this.replace);
+};
+
+/**
+ * Test if any matcher in the list matches against the source
+ * @this {Array}
+ * @param {string} source Source
+ * @return {boolean} Match result
+ */
+function matchersTest(source) {
+  return this.some(function(matcher) {
+    return matcher.test(source);
+  });
+}
+
+/**
+ * Executes the first macther in the list that matches against the source
+ * @this {Array}
+ * @param {string} source Source
+ * @return {string} Cleaned up result
+ */
+function matchersExec(source) {
+  var matcher = this.reduce(function(matcher, newMatcher) {
+    return matcher || (newMatcher.test(source) ? newMatcher : null);
+  }, null);
+
+  return matcher.exec(source);
+}
+
+var NPM_SCHEME_PATTERN = '^npm:/{0,3}(?!/)';
+// var NPM_SCHEME_PATTERN_VALID_ONLY = '^npm:(?:/?|///)(?!\\/)';
+var NPM_PREFIX_PATTERN = '^' + escapeStringRegexp('npm+');
+
+/**
+ * Creates a list of matchers from the config, providing default matchers if necessary
+ *
+ * @param {object} config The user config from the `.bowerrc` file.
+ * @return {Array.<Matcher>} List of matchers.
+ */
+exports.getFromConfig = function getFromConfig(config) {
+  config = config || {};
+
+  var patterns = config.match || [];
+
+  if (typeof patterns !== 'object' || !Array.isArray(patterns)) {
+    patterns = [patterns];
+  }
+
+  // Handle v0.2.0 style config
+  if (config.matchPrefix) {
+    if (typeof config.ignoreMatchDefaults === 'undefined') {
+      config.ignoreMatchDefaults = true;
+    }
+    patterns.unshift({
+      pattern: '^' + escapeStringRegexp(config.matchPrefix),
+      replace: ('stripPrefix' in config) ? Boolean(config.stripPrefix) : true
+    });
+  }
+
+  if (!config.ignoreMatchDefaults) {
+    patterns.push({
+      pattern: NPM_SCHEME_PATTERN,
+      flags: 'i',
+      replace: true
+    });
+    patterns.push({
+      pattern: NPM_PREFIX_PATTERN,
+      replace: true
+    });
+  }
+
+  var matchers = patterns.map(function(pattern) {
+    if (typeof pattern === 'string') {
+      pattern = {
+        pattern: pattern
+      };
+    }
+
+    if (pattern instanceof RegExp) {
+      pattern = {
+        regexp: pattern
+      };
+    }
+
+    if (typeof pattern !== 'object' || !pattern) {
+      throw new Error('Invalid match value: ' + pattern);
+    }
+
+    var regexp = pattern.regexp || new RegExp(pattern.pattern, pattern.flags);
+    var replace;
+
+    if (pattern.replace === true) {
+      replace = '';
+    } else if (pattern.replace === false || pattern.replace === undefined) {
+      replace = undefined;
+    } else {
+      replace = pattern.replace;
+    }
+
+    return new Matcher(regexp, replace);
+  });
+
+  matchers.test = matchersTest;
+  matchers.exec = matchersExec;
+
+  return matchers;
+};
+

--- a/src/matcher-utils.js
+++ b/src/matcher-utils.js
@@ -1,7 +1,7 @@
 /**
  * The MIT License (MIT)
  *
- * Copyright (c) 2016 Mickael Jeanroy
+ * Copyright (c) 2016 Mathieu Hofman
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/resolver.js
+++ b/src/resolver.js
@@ -33,21 +33,24 @@ var npmUtils = require('./npm-utils');
 var download = require('./download');
 var extract = require('./extract');
 var bowerUtils = require('./bower-utils');
+var matcherUtils = require('./matcher-utils');
 
-module.exports = function resolver() {
-  var NPM_SCHEME = 'npm://';
+module.exports = function resolver(bower) {
+  // Read configuration passed via .bowerrc
+  var matchers = matcherUtils.getFromConfig(bower.config.bowerNpmResolver);
 
   /**
    * Extract package name from package source.
    * The source is formatted such as:
-   *    npm://[package]#[version]
+   *    npm:[package]#[version]
    *
    * @param {string} source Source read from `bower.json` file.
    * @return {string} Package name extracted from given source.
    */
-  var extractPackageName = function (source) {
-    var withoutScheme = source.slice(NPM_SCHEME.length);
-    var withoutVersion = withoutScheme.split('#')[0];
+  var extractPackageName = function(source) {
+    var matchedSource = matchers.exec(source);
+    var withoutVersion = matchedSource.split('#')[0];
+
     return withoutVersion;
   };
 
@@ -56,13 +59,13 @@ module.exports = function resolver() {
 
     /**
      * Match method tells whether resolver supports given source.
-     * The resolver matches entries whose package value in `bower.json` starts with `npm://` string.
+     * The resolver matches entries whose package value in `bower.json` starts with `npm:` string.
      *
      * @param {string} source Source from `bower.json`.
      * @return {boolean} `true` if source match this resolver, `false` otherwise.
      */
     match: function(source) {
-      return source.indexOf(NPM_SCHEME) === 0;
+      return matchers.test(source);
     },
 
     /**

--- a/test/bower-utils-spec.js
+++ b/test/bower-utils-spec.js
@@ -129,4 +129,33 @@ describe('bower-utils', function() {
       done();
     });
   });
+
+  it('should normalize scoped package names', function(done) {
+    var config = {
+      name: '@scope/my-package',
+      description: 'This is a fake scoped package'
+    };
+
+    var normalizedName = 'scope-my-package';
+
+    fs.writeFileSync(path.join(tmpDir.name, 'package.json'), JSON.stringify(config, null, 2), 'utf-8');
+
+    var p = bowerUtil.patchConfiguration(tmpDir.name);
+    expect(p).toBeDefined();
+
+    p.then(function() {
+      expect(fs.statSync(path.join(tmpDir.name, 'bower.json')).isFile()).toBe(true);
+
+      var bowerJson = JSON.parse(fs.readFileSync(path.join(tmpDir.name, 'bower.json'), 'utf-8'));
+      expect(bowerJson.name).toEqual(normalizedName);
+    });
+
+    p.catch(function() {
+      jasmine.fail();
+    });
+
+    p.finally(function() {
+      done();
+    });
+  });
 });

--- a/test/matcher-utils-spec.js
+++ b/test/matcher-utils-spec.js
@@ -87,6 +87,11 @@ describe('matcher-utils', function() {
         pattern: '^mycompany'
       }
     },
+    'object with prefix': {
+      match: {
+        prefix: 'mycompany'
+      }
+    },
     'object with replace=false': {
       match: {
         pattern: '^mycompany',
@@ -131,7 +136,7 @@ describe('matcher-utils', function() {
   forEachObjectAsMap({
     'replace=true': {
       match: {
-        pattern: '^mycompany-',
+        prefix: 'mycompany-',
         replace: true
       }
     },

--- a/test/matcher-utils-spec.js
+++ b/test/matcher-utils-spec.js
@@ -1,0 +1,197 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Mickael Jeanroy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+var matcherUtils = require('../src/matcher-utils');
+
+function forEachObjectAsMap(obj, callback) {
+  Object.keys(obj).forEach(function(key) {
+    callback(obj[key], key, obj);
+  });
+}
+
+describe('matcher-utils', function() {
+  it('should match npm source by default', function() {
+    var matchers = matcherUtils.getFromConfig();
+
+    expect(matchers.test('npm+test')).toBe(true);
+    expect(matchers.test('npm:test')).toBe(true);
+    expect(matchers.test('npm:test#~1.0.0')).toBe(true);
+    expect(matchers.test('npm:@scope/test#~1.0.0')).toBe(true);
+    expect(matchers.test('test')).toBe(false);
+  });
+
+  describe('should match only valid variations of npm scheme.', function() {
+    var matchers = matcherUtils.getFromConfig();
+
+    it('accepts valid URIs', function() {
+      // a urn type URI (no authority) where package name is the whole path
+      expect(matchers.test('npm:test')).toBe(true);
+
+      // a urn type URI (no authority) where package name is prefixed by a / (i.e. absolute path)
+      expect(matchers.test('npm:/test')).toBe(true);
+
+      // URI with empty authority (package name is prefixed by a /)
+      expect(matchers.test('npm:///test')).toBe(true);
+
+      // URI with empty authority (full package name is prefixed by a /, @scope is considered a directory)
+      expect(matchers.test('npm:///@scope/test')).toBe(true);
+
+      // URIs are case insensitive
+      expect(matchers.test('NPM:test')).toBe(true);
+    });
+
+    it('accepts invalid, yet common URIs', function() {
+      // URI where the package name is the authority
+      expect(matchers.test('npm://test')).toBe(true);
+
+      // URI where the scope is the authority and scoped name is the path
+      expect(matchers.test('npm://@scope/test')).toBe(true);
+    });
+
+    it('rejects invalid URIs', function() {
+      // Path has too many slashes
+      expect(matchers.test('npm:////test')).toBe(false);
+    });
+  });
+
+  forEachObjectAsMap({
+    'string': {
+      match: '^mycompany'
+    },
+    'RegExp': {
+      match: /^mycompany/
+    },
+    'object': {
+      match: {
+        pattern: '^mycompany'
+      }
+    },
+    'object with replace=false': {
+      match: {
+        pattern: '^mycompany',
+        replace: false
+      }
+    },
+    'array': {
+      match: [
+        '^myothercompany',
+        '^mycompany'
+      ]
+    },
+    'matchPrefix': {
+      matchPrefix: 'mycompany',
+      stripPrefix: false
+    }
+  }, function(config, type) {
+    var matchers;
+
+    it('should parse config when pattern passed as a ' + type, function() {
+      matchers = matcherUtils.getFromConfig(config);
+      expect(matchers).toBeDefined();
+    });
+
+    it('should match a custom pattern passed as a ' + type, function() {
+      expect(matchers.test('mycompany-test')).toBe(true);
+      expect(matchers.test('test')).toBe(false);
+    });
+
+    if (type !== 'matchPrefix') {
+      it('should keep matching defaults when custom pattern passed as a ' + type, function() {
+        expect(matchers.test('npm:test')).toBe(true);
+        expect(matchers.test('npm+test')).toBe(true);
+      });
+    }
+
+    it('should not replace from custom pattern passed as a ' + type, function() {
+      expect(matchers.exec('mycompany-test')).toEqual('mycompany-test');
+    });
+  });
+
+  forEachObjectAsMap({
+    'replace=true': {
+      match: {
+        pattern: '^mycompany-',
+        replace: true
+      }
+    },
+    'replace with empty string': {
+      match: {
+        pattern: '^mycompany-',
+        replace: ''
+      }
+    },
+    'replace with string': {
+      match: {
+        pattern: '^mycompany-te',
+        replace: 'te'
+      }
+    },
+    'replace with regexp result': {
+      match: {
+        pattern: '^mycompany-(test)',
+        replace: '$1'
+      }
+    },
+    'matchPrefix': {
+      matchPrefix: 'mycompany-'
+    },
+    'matchPrefix with stripPrefix=true': {
+      matchPrefix: 'mycompany-',
+      stripPrefix: true
+    }
+  }, function(config, type) {
+    it('should strip/replace when ' + type, function() {
+      var matchers = matcherUtils.getFromConfig(config);
+
+      expect(matchers.exec('mycompany-test')).toEqual('test');
+    });
+  });
+
+  forEachObjectAsMap({
+    'ignoreMatchDefaults=true': {
+      match: '^mycompany',
+      ignoreMatchDefaults: true
+    },
+    'matchPrefix': {
+      matchPrefix: 'mycompany'
+    }
+  }, function(config, type) {
+    it('should ignore the defaults when ' + type, function() {
+      var matchers = matcherUtils.getFromConfig(config);
+
+      expect(matchers.test('npm:test')).toBe(false);
+      expect(matchers.test('npm+test')).toBe(false);
+    });
+  });
+
+  it('should not match anything with an empty match list', function() {
+    var matchers = matcherUtils.getFromConfig({
+      match: [],
+      ignoreMatchDefaults: true
+    });
+
+    expect(matchers.test('test')).toBe(false);
+    expect(matchers.test('')).toBe(false);
+  });
+});

--- a/test/matcher-utils-spec.js
+++ b/test/matcher-utils-spec.js
@@ -1,7 +1,7 @@
 /**
  * The MIT License (MIT)
  *
- * Copyright (c) 2016 Mickael Jeanroy
+ * Copyright (c) 2016 Mathieu Hofman
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/resolver-spec.js
+++ b/test/resolver-spec.js
@@ -40,15 +40,8 @@ describe('resolver', function() {
     });
   });
 
-  it('should match npm source by default', function() {
-    expect(resolver.match('npm://test')).toBe(true);
-    expect(resolver.match('npm://test#~1.0.0')).toBe(true);
-    expect(resolver.match('npm://@scope/test#~1.0.0')).toBe(true);
-    expect(resolver.match('test')).toBe(false);
-  });
-
   it('should get list of releases', function(done) {
-    var source = 'npm://bower';
+    var source = 'npm:bower';
     var defer = Q.defer();
     var promise = defer.promise;
     spyOn(npmUtils, 'releases').and.returnValue(promise);
@@ -94,7 +87,7 @@ describe('resolver', function() {
     var p4 = d3.promise;
     spyOn(bowerUtils, 'patchConfiguration').and.returnValue(p4);
 
-    var source = 'npm://bower#~1.7.0';
+    var source = 'npm:bower#~1.7.0';
     var target = '1.7.7';
 
     var result = resolver.fetch({


### PR DESCRIPTION
Implement package source matching against a list of regexp match patterns.

Implement `npm:` URI scheme as a default match pattern.
Keep old `npm+` prefix as another default match pattern.
Keep support for `matchPrefix` configuration of version 0.2.0.

The `npm:` scheme regexp does allow for `npm://` style URI, even though those are not actually appropriate in this use case. A `//` is used to indicate the start of the authority, which means the package name would end up being the "host" of the uri. It gets even more murky with scoped package names.

This PR also includes a fix for the package name normalization of scoped packages that don't include a `bower.json` file. Bower doesn't allow nested package names or `@`.

This should fix #3 