### PR TITLE
Fixes #10 by using a single directory (in bower's cache directory) instead of individual tmp directories

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
   "homepage": "https://github.com/mjeanroy/bower-npm-resolver",
   "dependencies": {
     "escape-string-regexp": "^1.0.5",
+    "mkdirp": "^0.5.1",
     "npm": ">=1.0.0",
     "q": "1.4.1",
     "request": "2.72.0",
     "tar-fs": "1.12.0",
-    "tmp": "0.0.28",
     "underscore": "1.8.3"
   },
   "devDependencies": {
@@ -47,6 +47,7 @@
     "gulp-jasmine": "2.3.0",
     "gulp-util": "3.0.7",
     "jasmine-core": "2.4.1",
-    "run-sequence": "1.1.5"
+    "run-sequence": "1.1.5",
+    "tmp": "0.0.28"
   }
 }

--- a/src/npm-utils.js
+++ b/src/npm-utils.js
@@ -30,7 +30,6 @@
  */
 
 var Q = require('q');
-var fs = require('fs');
 var npm = require('npm');
 var path = require('path');
 
@@ -131,14 +130,10 @@ module.exports = {
    * @return {Promise} The promise object.
    */
   downloadTarball: function(pkg, version, dir) {
-    var oldCWD = process.cwd();
     process.chdir(dir);
     return execPackCommand([pkg + '@' + version])
       .then(function(filename) {
         return path.resolve(dir || process.cwd(), filename[0]);
-      })
-      .finally(function() {
-        process.chdir(oldCWD);
       });
   }
 };

--- a/test/resolver-spec.js
+++ b/test/resolver-spec.js
@@ -28,16 +28,30 @@ var factory = require('../src/resolver');
 var npmUtils = require('../src/npm-utils');
 var extract = require('../src/extract');
 var bowerUtils = require('../src/bower-utils');
+var tmp = require('tmp');
 
 describe('resolver', function() {
   var resolver;
+  var tmpDir;
 
   beforeEach(function() {
+    tmpDir = tmp.dirSync({
+      unsafeCleanup: true
+    });
+
     resolver = factory({
-      config: {},
+      config: {
+        storage: {
+          packages: tmpDir.name
+        }
+      },
       version: '1.7.7',
       logger: jasmine.createSpyObj('logger', ['debug'])
     });
+  });
+
+  afterEach(function() {
+    tmpDir.removeCallback();
   });
 
   it('should get list of releases', function(done) {


### PR DESCRIPTION
By using a single directory for downloading (bower's cache directory), the issue described in #10 is avoided.  All packages now downloaded to: `[bower cache directory]/npm-resolver/compressed/` and are extracted into `[bower cache directory]/npm-resolver/uncompressed/[module name]/[module version]`.

Previously, `bower-npm-resolver` was quite diligent about cleaning up the temporary directories it creates.  Most of this cleanup process was removed for the sake of simplicity.  However, a call to `bower cache clean` will delete all temporary files and directories created by this module, which should be intuitive to end users.

Additionally, note that the module `chdir()`s to the `compressed` directory, but never `chdir()`s back out to the original directory.  This was the root cause of the problem described in #10.  This doesn't seem have any noticeable consequences.

On Windows, the default bower cache directory is `%LOCALAPPDATA%\bower\cache`.