### PR TITLE
Use global NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,11 +27,14 @@
     "url": "https://github.com/mjeanroy/bower-npm-resolver/issues"
   },
   "homepage": "https://github.com/mjeanroy/bower-npm-resolver",
+  "engines": {
+    "npm": ">=1.0.0"
+  },
   "dependencies": {
     "escape-string-regexp": "^1.0.5",
     "mkdirp": "^0.5.1",
-    "npm": ">=1.0.0",
     "q": "1.4.1",
+    "requireg": "^0.1.5",
     "tar-fs": "1.13.2",
     "underscore": "1.8.3"
   },

--- a/src/npm-utils.js
+++ b/src/npm-utils.js
@@ -29,8 +29,9 @@
  *  - Rejected with the error returned from NPM.
  */
 
+var requireg = require('requireg');
 var Q = require('q');
-var npm = require('npm');
+var npm = requireg('npm');
 var path = require('path');
 
 var wrapCallback = function(deferred) {


### PR DESCRIPTION
Use the global npm package instead of installing npm as a dependency.

This makes the install of this resolver much lighter since it doesn't need to pull in npm and all of its dependencies.